### PR TITLE
Fix wrong user agent and set it to the GitHub repo

### DIFF
--- a/php/audimeta_proxy.php
+++ b/php/audimeta_proxy.php
@@ -59,7 +59,7 @@ curl_setopt_array($curl, [
     CURLOPT_RETURNTRANSFER => true,
     CURLOPT_HTTPHEADER => [
         'Accept: application/json',
-        'User-Agent: AudibleMetaBot/1.0 (+https://seriescomplete.lily-pad.uk)'
+        'User-Agent: AudibleMetaBot/1.0 (+https://github.com/xFrieDSpuDx/completeseries)'
     ]
 ]);
 


### PR DESCRIPTION
The link used in the user agent was incorrect. It did not bother me, but now that it is "released," I want to fix it. It does not matter much if it points to your GitHub or the website. GitHub is usually easier because I can contact you more easily if I find bugs or overuse. Free to change

(seriescomplete vs completeseries)