### PR TITLE
Refactor: Switch to Alpine/Nginx/FPM to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,29 @@
-FROM php:8.2-apache
+FROM php:8.2-fpm-alpine
 
+# Install Nginx
+RUN apk add --no-cache nginx
+
+# Configure Nginx Logging
+# Redirect access logs to stdout and error logs to stderr
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
+
+# Configure Nginx
+RUN rm /etc/nginx/http.d/default.conf
+COPY nginx.conf /etc/nginx/http.d/default.conf
+
+# Setup Work Dir
+WORKDIR /var/www/html
+
+# Copy application files
 COPY . /var/www/html/
 
+# Fix permissions
 RUN chown -R www-data:www-data /var/www/html/ \
     && chmod -R 755 /var/www/html/
 
+# Expose port 80
 EXPOSE 80
 
-CMD ["apache2-foreground"]
+# Start Nginx and PHP-FPM
+CMD ["/bin/sh", "-c", "php-fpm -D && nginx -g 'daemon off;'"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /var/www/html;
+    index index.html index.php;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    # Pass PHP scripts to FastCGI server
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    # Deny access to . files (like .git, .env)
+    location ~ /\. {
+        deny all;
+    }
+}


### PR DESCRIPTION
Switching from apache2 to nginx/fpm reduces the image size from about 500 MB to 85 MB, on top of the performance gains of nginx/fpm over apache2. This could be implemented with a ':nginx-fpm' image tag, rather than ':latest', for anyone who prefers to keep apache2.