### PR TITLE
Add Unraid Docker Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-13 - Docker package publishing
 
+- Added an Unraid Docker template using bridge networking, host port 8080, and the 512px Complete Series favicon.
 - Restored GitHub Container Registry publishing for the V2 Docker image.
 - Documented the published `ghcr.io/xfriedspudx/completeseries:latest` image.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change log
 
-## 2026-06-13 - Docker package publishing
+## 2026-06-15 - Unraid Docker template
 
 - Added an Unraid Docker template using bridge networking, host port 8080, and the 512px Complete Series favicon.
+
+## 2026-06-13 - Docker package publishing
+
 - Restored GitHub Container Registry publishing for the V2 Docker image.
 - Documented the published `ghcr.io/xfriedspudx/completeseries:latest` image.
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The published container image is available from GitHub Container Registry:
 docker run --rm -p 8080:80 ghcr.io/xfriedspudx/completeseries:latest
 ```
 
+An Unraid template is available at [templates/complete-series.xml](templates/complete-series.xml). It uses Docker bridge networking, host port `8080`, and container port `80`.
+
 To bake in a default Google Books key for the browser app, set `VITE_GOOGLE_BOOKS_API_KEY` before building. Users can still enter their own key in the scan filters.
 
 Docker validation steps are listed in [Setup and configuration](docs/setup-configuration.md#docker-validation-checklist).

--- a/templates/complete-series.xml
+++ b/templates/complete-series.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>complete-series</Name>
+  <Repository>ghcr.io/xfriedspudx/completeseries:latest</Repository>
+  <Registry>https://github.com/xFrieDSpuDx/completeseries/pkgs/container/completeseries</Registry>
+  <Network>bridge</Network>
+  <MyIP/>
+  <MyMAC/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/xFrieDSpuDx/completeseries/issues</Support>
+  <Project>https://github.com/xFrieDSpuDx/completeseries</Project>
+  <ReadMe>https://github.com/xFrieDSpuDx/completeseries#readme</ReadMe>
+  <Overview>Complete Series helps find gaps in audiobook series stored in Audiobookshelf.</Overview>
+  <Category>MediaApp:Books</Category>
+  <Description>Complete Series compares your Audiobookshelf library with selected catalogue providers and shows audiobook series that may be incomplete.</Description>
+  <WebUI>http://[IP]:[PORT:80]</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/xFrieDSpuDx/completeseries/main/templates/complete-series.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/xFrieDSpuDx/completeseries/main/public/favicon/favicon-512x512.png</Icon>
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+  <Config Name="WebUI" Target="80" Default="8080" Mode="tcp" Description="Web interface port" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+  <TailscaleStateDir/>
+</Container>


### PR DESCRIPTION
## Summary
Adds an Unraid Docker template for Complete Series.

## Details
- Uses the published GHCR image: `ghcr.io/xfriedspudx/completeseries:latest`
- Uses Docker bridge networking by default
- Maps host port `8080` to container port `80`
- Uses the 512px Complete Series favicon
- Documents the template in the README
- Updated changelog

## Validation
- Template checks passed locally
- Branch pushed as `unraid-template`